### PR TITLE
Search for movies only

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ log = CPLog(__name__)
 class nCore(TorrentProvider, MovieProvider):
     urls = {
         'login': 'https://ncore.cc/login.php',
-        'search': 'https://ncore.cc/torrents.php?mire=%s&miben=name&tipus=all&submit=Ok&searchedfrompotato=true&jsons=true&tags=',
+        'search': 'https://ncore.cc/torrents.php?nyit_filmek_resz=true&kivalasztott_tipus[]=xvid_hun&kivalasztott_tipus[]=xvid&kivalasztott_tipus[]=dvd_hun&kivalasztott_tipus[]=dvd&kivalasztott_tipus[]=dvd9_hun&kivalasztott_tipus[]=dvd9&kivalasztott_tipus[]=hd_hun&kivalasztott_tipus[]=hd&mire=%s&miben=name&tipus=kivalasztottak_kozott&submit.x=0&submit.y=0&submit=Ok&tags=&searchedfrompotato=true&jsons=true'
     }
 
     http_time_between_calls = 1  # seconds


### PR DESCRIPTION
Since CouchPotato searches only for movies mostly, it is better to let it search only for movie categories so the results which are returned will be more relevant.